### PR TITLE
Removed extra connection to corkus city crossroads

### DIFF
--- a/territories.json
+++ b/territories.json
@@ -4725,8 +4725,7 @@
       "Road to Mine",
       "Corkus Forest",
       "Industrial Clearing",
-      "Corkus City",
-      "Picnic Pond"
+      "Corkus City"
     ],
     "Guild": {
       "uuid": "",
@@ -8229,8 +8228,7 @@
     "Trading Routes": [
       "Avos Territory",
       "Corkus Forest",
-      "Corkus City",
-      "Corkus City Crossroads"
+      "Corkus City"
     ],
     "Guild": {
       "uuid": "",


### PR DESCRIPTION
Wyn changelog: https://discord.com/channels/143852930036924417/1274572579297824849/1274773288777678849
World Changes -> Removed Corkus City South <-> Corkus Forest North territory connection