### PR TITLE
Remove wrong route between "Gates to Aelumia" and "The Lumbermill"

### DIFF
--- a/territories.json
+++ b/territories.json
@@ -12501,8 +12501,7 @@
     },
     "Trading Routes": [
       "Forts in Fall",
-      "Espren",
-      "Gates to Aelumia"
+      "Espren"
     ],
     "Location": {
       "start": [


### PR DESCRIPTION
Remove wrong route from "The Lumbermill" to "Gates to Aelumia".

Official API will support it next week. This PR might be unnecessary.
Thank you for your work on this project